### PR TITLE
Handle CryptographicException when unprotecting the quote cookie.

### DIFF
--- a/EndPointCommerce.Tests/WebApi/Services/QuoteCookieManagerTests.cs
+++ b/EndPointCommerce.Tests/WebApi/Services/QuoteCookieManagerTests.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using EndPointCommerce.WebApi.Services;
 using Microsoft.AspNetCore.Http;
 using Moq;
@@ -49,6 +50,29 @@ public class QuoteCookieManagerTests
 
         var mockRequest = new Mock<HttpRequest>();
         mockRequest.Setup(x => x.Cookies).Returns(mockCookies.Object);
+
+        // Act
+        var result = _subject.GetQuoteIdFromCookie(mockRequest.Object);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetQuoteIdFromCookie_ReturnsNull_WhenTheCallToTheDataProtectorThrowsAnError()
+    {
+        // Arrange
+        var mockCookies = new Mock<IRequestCookieCollection>();
+        mockCookies
+            .Setup(m => m["EndPointCommerce_QuoteId"])
+            .Returns("test_protected_quote_id");
+
+        var mockRequest = new Mock<HttpRequest>();
+        mockRequest.Setup(x => x.Cookies).Returns(mockCookies.Object);
+
+        _mockDataProtector
+            .Setup(x => x.Unprotect("test_protected_quote_id"))
+            .Throws(new CryptographicException("test_exception"));
 
         // Act
         var result = _subject.GetQuoteIdFromCookie(mockRequest.Object);

--- a/EndPointCommerce.WebApi/Services/QuoteCookieManager.cs
+++ b/EndPointCommerce.WebApi/Services/QuoteCookieManager.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+
 namespace EndPointCommerce.WebApi.Services;
 
 public interface IQuoteCookieManager
@@ -24,7 +26,14 @@ public class QuoteCookieManager : IQuoteCookieManager
         var quoteCookie = request.Cookies[COOKIE_NAME];
         if (quoteCookie == null) return null;
 
-        return int.Parse(_protector.Unprotect(quoteCookie));
+        try
+        {
+            return int.Parse(_protector.Unprotect(quoteCookie));
+        }
+        catch (CryptographicException)
+        {
+            return null;
+        }
     }
 
     public void SetQuoteIdCookie(HttpResponse response, int quoteId)


### PR DESCRIPTION
This prevents errors when data protection keys are lost. Instead of a crash, the user will just lose their quote.